### PR TITLE
Added managed public overload for `erf` and `erfc` with `double[]`

### DIFF
--- a/source/gfoidl.Stochastics/SpecialFunctions.cs
+++ b/source/gfoidl.Stochastics/SpecialFunctions.cs
@@ -26,6 +26,7 @@ namespace gfoidl.Stochastics
         /// </summary>
         /// <param name="x">The argument.</param>
         /// <returns>The value of the gaussian error function by <paramref name="x" />.</returns>
+        /// <seealso cref="Erf(double[])" />
         // https://math.stackexchange.com/questions/263216/error-function-erf-with-better-precision/1889960#1889960
         public static double Erf(double x)
         {
@@ -189,6 +190,7 @@ namespace gfoidl.Stochastics
         /// </summary>
         /// <param name="x">The argument.</param>
         /// <returns>The value of the complementare error funnction by <paramref name="x" />.</returns>
+        /// <seealso cref="Erfc(double[])" />
         public static double Erfc(double x)
         {
             if (_erfNativeLinux)
@@ -359,6 +361,46 @@ namespace gfoidl.Stochastics
                 else
                     return 2.0 - tiny;
             }
+        }
+        //---------------------------------------------------------------------
+        /// <summary>
+        /// Returns the values of the gaussian error function at the arguments given
+        /// by <paramref name="values" />.
+        /// </summary>
+        /// <param name="values">The arguments.</param>
+        /// <returns>erf</returns>
+        /// <seealso cref="Erf(double)" />
+        public static unsafe double[] Erf(double[] values)
+        {
+            if (values == null) ThrowHelper.ThrowArgumentNull(nameof(values));
+
+            var results = new double[values.Length];
+
+            fixed (double* pValues  = values)
+            fixed (double* pResults = results)
+                Erf(pValues, pResults, values.Length);
+
+            return results;
+        }
+        //---------------------------------------------------------------------
+        /// <summary>
+        /// Returns the values of the complementary error function at the arguments given
+        /// by <paramref name="values" />.
+        /// </summary>
+        /// <param name="values">The arguments.</param>
+        /// <returns>erfc</returns>
+        /// <seealso cref="Erfc(double)" />
+        public static unsafe double[] Erfc(double[] values)
+        {
+            if (values == null) ThrowHelper.ThrowArgumentNull(nameof(values));
+
+            var results = new double[values.Length];
+
+            fixed (double* pValues  = values)
+            fixed (double* pResults = results)
+                Erfc(pValues, pResults, values.Length);
+
+            return results;
         }
         //---------------------------------------------------------------------
         internal static unsafe void Erf(double* values, double* result, int size)

--- a/tests/gfoidl.Stochastics.Tests/SpecialFunctionsTests/ErrorFunction.cs
+++ b/tests/gfoidl.Stochastics.Tests/SpecialFunctionsTests/ErrorFunction.cs
@@ -25,13 +25,12 @@ namespace gfoidl.Stochastics.Tests.SpecialFunctionsTests
         }
         //---------------------------------------------------------------------
         [Test]
-        public unsafe void Erf_Vector_given___correct_result()
+        public void Erf_Vector_given___correct_result()
         {
             (double x, double erf)[] testData = TestData().ToArray();
 
-            double* values  = stackalloc double[testData.Length];
-            double* results = stackalloc double[testData.Length];
-            var expected    = new double[testData.Length];
+            var values   = new double[testData.Length];
+            var expected     = new double[testData.Length];
 
             for (int i = 0; i < testData.Length; ++i)
             {
@@ -39,20 +38,19 @@ namespace gfoidl.Stochastics.Tests.SpecialFunctionsTests
                 expected[i] = testData[i].erf;
             }
 
-            Erf(values, results, testData.Length);
+            double[] results = Erf(values);
 
             for (int i = 0; i < testData.Length; ++i)
                 Assert.AreEqual(expected[i], results[i], 1e-6, "failure at index {0}", i);
         }
         //---------------------------------------------------------------------
         [Test]
-        public unsafe void Erfc_Vector_given___correct_result()
+        public void Erfc_Vector_given___correct_result()
         {
             (double x, double erf)[] testData = TestData().ToArray();
 
-            double* values  = stackalloc double[testData.Length];
-            double* results = stackalloc double[testData.Length];
-            var expected    = new double[testData.Length];
+            var values   = new double[testData.Length];
+            var expected     = new double[testData.Length];
 
             for (int i = 0; i < testData.Length; ++i)
             {
@@ -60,7 +58,7 @@ namespace gfoidl.Stochastics.Tests.SpecialFunctionsTests
                 expected[i] = 1d - testData[i].erf;
             }
 
-            Erfc(values, results, testData.Length);
+            double[] results = Erfc(values);
 
             for (int i = 0; i < testData.Length; ++i)
                 Assert.AreEqual(expected[i], results[i], 1e-6, "failure at index {0}", i);

--- a/tests/gfoidl.Stochastics.Tests/gfoidl.Stochastics.Tests.csproj
+++ b/tests/gfoidl.Stochastics.Tests/gfoidl.Stochastics.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp2.0</TargetFramework>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/gfoidl/Stochastics/issues/34