### PR TITLE
Instead of a loop-reduction in simd, Vector.Dot is used

### DIFF
--- a/source/gfoidl.Stochastics/Statistics/Sample.AverageVarianceCore.cs
+++ b/source/gfoidl.Stochastics/Statistics/Sample.AverageVarianceCore.cs
@@ -100,8 +100,8 @@ namespace gfoidl.Stochastics.Statistics
                         i += Vector<double>.Count;
                     }
 
-                    for (int j = 0; j < Vector<double>.Count; ++j)
-                        avg += avgVec[j];
+                    // Reduction -- https://github.com/gfoidl/Stochastics/issues/43
+                    avg += Vector.Dot(avgVec, Vector<double>.One);
                 }
 
                 for (; i < n; ++i)

--- a/source/gfoidl.Stochastics/Statistics/Sample.Delta.cs
+++ b/source/gfoidl.Stochastics/Statistics/Sample.Delta.cs
@@ -93,8 +93,8 @@ namespace gfoidl.Stochastics.Statistics
                         i += Vector<double>.Count;
                     }
 
-                    for (int j = 0; j < Vector<double>.Count; ++j)
-                        delta += deltaVec[j];
+                    // Reduction -- https://github.com/gfoidl/Stochastics/issues/43
+                    delta += Vector.Dot(deltaVec, Vector<double>.One);
                 }
 
                 for (; i < n; ++i)

--- a/source/gfoidl.Stochastics/Statistics/Sample.MinMax.cs
+++ b/source/gfoidl.Stochastics/Statistics/Sample.MinMax.cs
@@ -106,6 +106,7 @@ namespace gfoidl.Stochastics.Statistics
                         i += Vector<double>.Count;
                     }
 
+                    // Reduction
                     for (int j = 0; j < Vector<double>.Count; ++j)
                     {
                         if (minVec[j] < min) min = minVec[j];

--- a/source/gfoidl.Stochastics/Statistics/Sample.SkewnessAndKurtosis.cs
+++ b/source/gfoidl.Stochastics/Statistics/Sample.SkewnessAndKurtosis.cs
@@ -104,11 +104,9 @@ namespace gfoidl.Stochastics.Statistics
                         i += Vector<double>.Count;
                     }
 
-                    for (int j = 0; j < Vector<double>.Count; ++j)
-                    {
-                        skewness += skewVec[j];
-                        kurtosis += kurtVec[j];
-                    }
+                    // Reduction -- https://github.com/gfoidl/Stochastics/issues/43
+                    skewness += Vector.Dot(skewVec, Vector<double>.One);
+                    kurtosis += Vector.Dot(kurtVec, Vector<double>.One);
                 }
 
                 for (; i < n; ++i)


### PR DESCRIPTION
Fixes https://github.com/gfoidl/Stochastics/issues/43